### PR TITLE
Strip spaces from creator surname

### DIFF
--- a/tdd-workflow-utility.rb
+++ b/tdd-workflow-utility.rb
@@ -444,7 +444,7 @@ def execute(function, config, log)
               metadata << v
             end
           end
-          creator = metadata[3].strip.split(',')[0]
+          creator = metadata[3].strip.split(',')[0].gsub(/\s/,'')
           date = metadata[5].to_s.strip
           pdf_new = creator + '_' + date + '_' + pdf
           FileUtils.cp object.join(pdf), "#{batch_dir}/#{pdf_new}"


### PR DESCRIPTION
Spaces in creator surname (e.g. "Van Dyke" or "de la Garza" cause problems on ingest. Strip spaces from creator name before forming pdf name. Retain spaces in metadata.