### PR TITLE
Add two new fields to CSV for ingest

### DIFF
--- a/lib/tdd.rb
+++ b/lib/tdd.rb
@@ -63,41 +63,45 @@ module TDD
       'dc.format.digitalOrigin',
       'dc.type.genre',
       'dc.description.abstract',
-      'dc.rights'
+      'dc.rights',
+      'dc.date.copyright',
+      'dcterms.accessRights'
     ]
   end
 
-  def get_dc_headers
-    [
-      'dc.identifier.other',
-      'dc.contributor.advisor',
-      'dc.contributor.committeeMember',
-      'dc.creator',
-      'dc.title',
-      'dc.date.issued',
-      'dc.description.department',
-      'dc.language.iso',
-      'dc.relation.ispartof',
-      'dc.subject',
-      'dc.type.dcmi',
-      'dc.format.mimetype',
-      'dc.format.digitalOrigin',
-      'dc.type.genre',
-      'dc.description.abstract',
-      'dc.rights'
-    ]
-  end
+  # This does not appear to be used - seh 20220727
+  # def get_dc_headers
+  #   [
+  #     'dc.identifier.other',
+  #     'dc.contributor.advisor',
+  #     'dc.contributor.committeeMember',
+  #     'dc.creator',
+  #     'dc.title',
+  #     'dc.date.issued',
+  #     'dc.description.department',
+  #     'dc.language.iso',
+  #     'dc.relation.ispartof',
+  #     'dc.subject',
+  #     'dc.type.dcmi',
+  #     'dc.format.mimetype',
+  #     'dc.format.digitalOrigin',
+  #     'dc.type.genre',
+  #     'dc.description.abstract',
+  #     'dc.rights'
+  #   ]
+  # end
 
-  def get_thesis_headers
-    [
-      'thesis.degree.discipline',
-      'thesis.degree.college',
-      'thesis.degree.department',
-      'thesis.degree.name',
-      'thesis.degree.level',
-      'thesis.degree.grantor',
-    ]
-  end
+  # This does not appear to be used - seh 20220727
+  # def get_thesis_headers
+  #   [
+  #     'thesis.degree.discipline',
+  #     'thesis.degree.college',
+  #     'thesis.degree.department',
+  #     'thesis.degree.name',
+  #     'thesis.degree.level',
+  #     'thesis.degree.grantor',
+  #   ]
+  # end
 
   def reorder(files, order)
     new_files = []


### PR DESCRIPTION
Added dc.date.copyright and dcterms.accessRights, which are needed to track which items are under copyright and to hold a note about usage of the thesis. These fields are needed now that all records have the same content in dc.rights and we can no longer use dc.rights to distinguish the open access items from the restricted access items.